### PR TITLE
build(deps): bump pytest to remove dependency on py

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
           name: Upload coverage
           command: |
             set -exu
-            ~/workspace/cc-test-reporter sum-coverage ~/workspace/coverage/*.json -p 4
+            ~/workspace/cc-test-reporter sum-coverage ~/workspace/coverage/*.json -p 3
             ~/workspace/cc-test-reporter upload-coverage
 
 workflows:
@@ -75,7 +75,6 @@ workflows:
           matrix:
             parameters:
               python-version:
-                - "3.6.14"
                 - "3.7.11"
                 - "3.8.12"
                 - "3.9.7"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,6 +16,8 @@ botocore==1.21.51
     #   s3transfer
 coverage==6.0
     # via -r requirements-dev.in
+exceptiongroup==1.0.0
+    # via pytest
 iniconfig==1.1.1
     # via pytest
 jmespath==0.10.0
@@ -26,11 +28,9 @@ packaging==21.0
     # via pytest
 pluggy==1.0.0
     # via pytest
-py==1.10.0
-    # via pytest
 pyparsing==2.4.7
     # via packaging
-pytest==6.2.5
+pytest==7.2.0
     # via -r requirements-dev.in
 python-dateutil==2.8.2
     # via botocore
@@ -38,7 +38,7 @@ s3transfer==0.5.0
     # via boto3
 six==1.16.0
     # via python-dateutil
-toml==0.10.2
+tomli==2.0.1
     # via pytest
 urllib3==1.26.7
     # via botocore

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setuptools.setup(
         'License :: OSI Approved :: MIT License',
         'Topic :: Database',
     ],
-    python_requires='>=3.6.0',
+    python_requires='>=3.7.11',
     install_requires=[
         'boto3>=1.18.51',
     ],


### PR DESCRIPTION
Unfortunately exceptiongroup that pytest now depends on isn't supported on Python 3.6 and so testing isn't possible, at least not without more time spent. Opting to remove support for Python 3.6. If we can figure out how to test on Python 3.6, can always bring it back.

DT-720