### PR TITLE
fix: work with recent apsw

### DIFF
--- a/sqlite_s3vfs.py
+++ b/sqlite_s3vfs.py
@@ -128,6 +128,9 @@ class S3VFSFile:
 
         return b"".join(_read())
 
+    def xSectorSize(self):
+        return 0
+
     def xFileControl(self, *args):
         return False
 


### PR DESCRIPTION
 It looks like from apsw 3.43.1.1 onwards, the virtual filesystem file needs the xSectorSize function.

Nothing in the apsw changelog at https://rogerbinns.github.io/apsw/changes.html makes this particular clear - the issue from 3.43.1.1 onwards was determined by running the tests for sqlite-s3vfs for each apsw version.

The sector size of "0" for some reason is the only one that makes the rollback tests pass

Thank you to @blueshed for the report.

Closes https://github.com/uktrade/sqlite-s3vfs/issues/24